### PR TITLE
Mostra corretamente o significado de jogos digitais

### DIFF
--- a/src/components/Description/Description.css
+++ b/src/components/Description/Description.css
@@ -22,4 +22,5 @@
     background-color: rgba(0, 0, 0, 0.1);
     border-radius: 1rem;
     padding: 0.5rem;
+    justify-content: center;
 }

--- a/src/components/Glossary/Glossary.js
+++ b/src/components/Glossary/Glossary.js
@@ -55,7 +55,7 @@ class Glossary extends Component {
 
     getCurrentObjLength = () => this.getCurrentObj().length;
 
-    getCurrentObj = () => acronyms[this.state.currentAcronym.toUpperCase()];
+    getCurrentObj = () => acronyms[this.state.currentAcronym];
 
     decreaseMeaning = async () => {
         const finalMeaningNum = this.state.currentMeaning === 0 ? this.getCurrentObjLength() - 1 : this.state.currentMeaning - 1;

--- a/src/index.js
+++ b/src/index.js
@@ -11,7 +11,7 @@ import './styles/odu/colors.css';
 import './styles/utils.css';
 
 ReactDOM.render((
-    <BrowserRouter>
+    <BrowserRouter basename={process.env.PUBLIC_URL}>
         <App />
     </BrowserRouter>
 ), document.getElementById('app'));


### PR DESCRIPTION
Previamente, a aplicação retornava um erro ao tentar acessar o significado de jogos digitais. Também alterei o css da caixinha de significado para centralizar o texto.

Edit: Como o propósito deste PR foi resolvido no refatoramento feito no #28, o foco mudou um pouco. As alterações agora são:

* centralizar o texto da caixa de significado
* consertar o problema de roteamento que havia no github pages

Closes #25 and closes #27.