### PR TITLE
Card de significados

### DIFF
--- a/src/components/ResultCard/ResultCard.css
+++ b/src/components/ResultCard/ResultCard.css
@@ -13,22 +13,22 @@
         'left-content right-content';
 }
 
-.result-card__container h1 {
+.result-card__title-1 {
     grid-area: title;
     margin: 0;
     line-height: 1.2em;
 }
 
-.result-card__container ul {
+.result-card__list-phrase {
     padding-left: 15px
 }
 
-.result-card__container li {
+.result-card__item-phrase {
     margin-bottom: 10px;
     font-style: italic;
 }
 
-.result-card__container .result-card__subtitle {
+.result-card__subtitle {
     grid-area: subtitle;
     font-family: 'Krub', 'sans-serif';
     font-weight: 500;
@@ -36,7 +36,7 @@
     font-style: italic;
 }
 
-.result-card__container .result-card__content h2 {
+.result-card__title-2 {
     margin-top: 20px;
     color: gray;
 }

--- a/src/components/ResultCard/ResultCard.css
+++ b/src/components/ResultCard/ResultCard.css
@@ -2,7 +2,7 @@
     background: #fff;
     font-family: 'Ikaros', sans-serif;
     border-radius: 10px;
-    padding: 30px 50px 30px 50px;
+    padding: 30px 50px;
     box-shadow: 0 1px 3px rgba(0,0,0,0.12), 0 1px 2px rgba(0,0,0,0.24);
     width: 100%;
     display: grid;

--- a/src/components/ResultCard/ResultCard.css
+++ b/src/components/ResultCard/ResultCard.css
@@ -1,0 +1,42 @@
+.result-card__container {
+    background: #fff;
+    font-family: 'Ikaros', sans-serif;
+    border-radius: 10px;
+    padding: 30px 50px 30px 50px;
+    box-shadow: 0 1px 3px rgba(0,0,0,0.12), 0 1px 2px rgba(0,0,0,0.24);
+    width: 100%;
+    display: grid;
+    grid-gap: 0 2em;
+    grid-template-areas:
+        'title title'
+        'subtitle subtitle'
+        'left-content right-content';
+}
+
+.result-card__container h1 {
+    grid-area: title;
+    margin: 0;
+    line-height: 1.2em;
+}
+
+.result-card__container ul {
+    padding-left: 15px
+}
+
+.result-card__container li {
+    margin-bottom: 10px;
+    font-style: italic;
+}
+
+.result-card__container .result-card__subtitle {
+    grid-area: subtitle;
+    font-family: 'Krub', 'sans-serif';
+    font-weight: 500;
+    color: gray;
+    font-style: italic;
+}
+
+.result-card__container .result-card__content h2 {
+    margin-top: 20px;
+    color: gray;
+}

--- a/src/components/ResultCard/ResultCard.js
+++ b/src/components/ResultCard/ResultCard.js
@@ -1,0 +1,28 @@
+import React from 'react';
+
+import './ResultCard.css';
+
+const Examples = ({ key, examples }) => examples.map((ex, index) => (
+    <li key={`${key}${index}`}>{ ex }</li>
+));
+
+const ResultCard = ({ result }) => (
+    <div className={"result-card__container"}>
+        <h1>{ result.entry }</h1>
+        <span className={"result-card__subtitle"}>{ result.type }</span>
+
+        <div className="result-card__content">
+            <h2>Descrição</h2>
+            <p>{ result.meaning }</p>
+        </div>
+
+        <div className="result-card__content">
+            <h2>Aplicações em frase</h2>
+            <ul>
+                <Examples key={ result.entry } examples={ result.examples } />
+            </ul>
+        </div>
+    </div>
+);
+
+export default ResultCard;

--- a/src/components/ResultCard/ResultCard.js
+++ b/src/components/ResultCard/ResultCard.js
@@ -3,22 +3,22 @@ import React from 'react';
 import './ResultCard.css';
 
 const Examples = ({ key, examples }) => examples.map((ex, index) => (
-    <li key={`${key}${index}`}>{ ex }</li>
+    <li className={"result-card__list-phrase"} key={`${key}${index}`}>{ ex }</li>
 ));
 
 const ResultCard = ({ result }) => (
     <div className={"result-card__container"}>
-        <h1>{ result.entry }</h1>
+        <h1 className={"result-card__title-1"}>{ result.entry }</h1>
         <span className={"result-card__subtitle"}>{ result.type }</span>
 
         <div className="result-card__content">
-            <h2>Descrição</h2>
+            <h2 className={"result-card__title-2"}>Descrição</h2>
             <p>{ result.meaning }</p>
         </div>
 
         <div className="result-card__content">
-            <h2>Aplicações em frase</h2>
-            <ul>
+            <h2 className={"result-card__title-2"}>Aplicações em frase</h2>
+            <ul className={"result-card__list-phrase"}>
                 <Examples key={ result.entry } examples={ result.examples } />
             </ul>
         </div>

--- a/src/index.css
+++ b/src/index.css
@@ -7,12 +7,12 @@ html, body {
 }
 
 @font-face {
-    font-family: Ikaros-Regular;
+    font-family: Ikaros;
     src: url(../assets/fonts/Ikaros-Regular.otf);
 }
 
 @font-face {
-    font-family: Jaapokki-Regular;
+    font-family: Jaapokki;
     src: url(../assets/fonts/Jaapokki-Regular.otf);
 }
 

--- a/src/index.html
+++ b/src/index.html
@@ -4,7 +4,7 @@
     <title>Glossario UFCG</title>
     <meta charset="utf-8" />
     <link href="assets/images/favicon.ico" rel="icon">
-    <link href="https://fonts.googleapis.com/css?family=Krub" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css?family=Krub:400,500" rel="stylesheet">
     <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
   </head>
   <body>


### PR DESCRIPTION
**Descrição do bug/feature:**
Card da nova UI com os significados dos termos pronto!
Atualiza `new-ui` com o código da `master`

**Solução adotada:**
Criação e estilização do componente do ResultCard.

- Design:

![image](https://user-images.githubusercontent.com/11728746/53931758-484f0400-4075-11e9-909f-bb208bd34f5c.png)

- Implementação:

![image](https://user-images.githubusercontent.com/11728746/53931766-52710280-4075-11e9-80b2-7671eb27f140.png)

**TODO:**
- [ ] Deixar o card responsivo
- [ ] Integrar o card com a busca

<!-- Ao terminar a descrição do PR, apague todos os comentários -->
