### PR TITLE
Conserta centralização de logo

### DIFF
--- a/src/components/Glossary/Glossary.js
+++ b/src/components/Glossary/Glossary.js
@@ -26,8 +26,8 @@ class Glossary extends Component {
         const randomEntry = this.getRandomEntry();
         return (
             <div className={"glossary__container"}>
-                <Link to={""}>
-                    <img className={"glossary__logo"} src={glossarioLogo} />
+                <Link to={""} className={"glossary__logo"}>
+                    <img src={glossarioLogo} />
                 </Link>
                 <Search className={"glossary__search"}
                         items={Object.keys(acronyms).sort()}


### PR DESCRIPTION
**Descrição do bug/feature:**
Logo na home não está centralizada
<!-- Descreva o bug ou a feature do PR -->

**Solução adotada:**
Centraliza logo mudando a aplicação da classe da imagem para o container Link.

- Antes:
![localhost_8000_(Nexus 5) (2)](https://user-images.githubusercontent.com/38431219/54245406-7b7b1280-450f-11e9-8670-f42756d5a7a6.png)

- Depois:
![localhost_8000_(Nexus 5) (3)](https://user-images.githubusercontent.com/38431219/54245408-7f0e9980-450f-11e9-91b4-5775f436e0a8.png)

<!-- Descreva a solução adotada para resolver o bug ou implementar a feature -->

**TODO:** n/a
<!-- Descreva o que ainda deve ser feito nesse PR ou em PRs futuros. Se não existir um TODO, preencher com N/A-->

<!-- Ao terminar a descrição do PR, apague todos os comentários -->
