### PR TITLE
Adicionando configuração de produção do webpack

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "react": "^16.7.0",
     "react-dom": "^16.7.0",
     "react-markdown": "^4.0.6",
-    "react-scripts": "2.1.3"
+    "react-scripts": "2.1.3",
+    "webpack-merge": "^4.2.1"
   },
   "husky": {
     "hooks": {
@@ -22,8 +23,8 @@
     }
   },
   "scripts": {
-    "start": "webpack-dev-server --progress --colors --inline --hot --host 0.0.0.0",
-    "build": "webpack",
+    "start": "webpack-dev-server --config ./webpack/webpack.dev.js --progress --colors --inline --hot --host 0.0.0.0",
+    "build": "webpack --config ./webpack/webpack.prod.js",
     "lint": "eslint ."
   },
   "eslintConfig": {

--- a/webpack/webpack.common.js
+++ b/webpack/webpack.common.js
@@ -3,17 +3,12 @@ const path = require('path');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const HtmlWebPackPlugin = require("html-webpack-plugin");
 
+const parentDir = path.join(__dirname, '../');
 
 const config = {
-    mode: 'development',
-    entry: ['react-dev-utils/webpackHotDevClient', './src/index.js'],
-    devServer: {
-        port: 8000,
-        contentBase: __dirname + '/public',
-        historyApiFallback: true,
-    },
+    entry: ['react-dev-utils/webpackHotDevClient', `${parentDir}/src/index.js`],
     output: {
-        path: path.resolve(__dirname, 'public'),
+        path: path.resolve(parentDir, 'public'),
         filename: 'bundle.[hash].js',
     },
     module: {

--- a/webpack/webpack.common.js
+++ b/webpack/webpack.common.js
@@ -8,7 +8,7 @@ const parentDir = path.join(__dirname, '../');
 const config = {
     entry: ['react-dev-utils/webpackHotDevClient', `${parentDir}/src/index.js`],
     output: {
-        path: path.resolve(parentDir, 'public'),
+        path: `${parentDir}/public/`,
         filename: 'bundle.[hash].js',
     },
     module: {
@@ -51,7 +51,7 @@ const config = {
             filename: 'style.css',
         }),
         new HtmlWebPackPlugin({
-            template: __dirname + "/src/index.html",
+            template: `${parentDir}/src/index.html`,
             filename: "index.html"
         })
     ]

--- a/webpack/webpack.common.js
+++ b/webpack/webpack.common.js
@@ -6,9 +6,9 @@ const HtmlWebPackPlugin = require("html-webpack-plugin");
 const parentDir = path.join(__dirname, '../');
 
 const config = {
-    entry: ['react-dev-utils/webpackHotDevClient', `${parentDir}/src/index.js`],
+    entry: [`${parentDir}/src/index.js`],
     output: {
-        path: `${parentDir}/public/`,
+        path: `${parentDir}public/`,
         filename: 'bundle.[hash].js',
     },
     module: {

--- a/webpack/webpack.dev.js
+++ b/webpack/webpack.dev.js
@@ -1,0 +1,12 @@
+const webpack = require('webpack');
+const merge = require('webpack-merge');
+const common = require('./webpack.common');
+
+module.exports = merge(common, {
+    devServer: {
+        port: 8000,
+        contentBase: __dirname + '/public',
+        historyApiFallback: true,
+    },
+    mode: 'development',
+});

--- a/webpack/webpack.dev.js
+++ b/webpack/webpack.dev.js
@@ -6,9 +6,10 @@ const common = require('./webpack.common');
 const parentDir = path.join(__dirname, '../');
 
 module.exports = merge(common, {
+    entry: ['react-dev-utils/webpackHotDevClient'],
     devServer: {
         port: 8000,
-        contentBase: `${parentDir}/public`,
+        contentBase: `${parentDir}public`,
         historyApiFallback: true,
     },
     mode: 'development',

--- a/webpack/webpack.dev.js
+++ b/webpack/webpack.dev.js
@@ -1,11 +1,14 @@
 const webpack = require('webpack');
 const merge = require('webpack-merge');
+const path = require('path');
 const common = require('./webpack.common');
+
+const parentDir = path.join(__dirname, '../');
 
 module.exports = merge(common, {
     devServer: {
         port: 8000,
-        contentBase: __dirname + '/public',
+        contentBase: `${parentDir}/public`,
         historyApiFallback: true,
     },
     mode: 'development',

--- a/webpack/webpack.prod.js
+++ b/webpack/webpack.prod.js
@@ -1,0 +1,7 @@
+const webpack = require('webpack');
+const merge = require('webpack-merge');
+const common = require('./webpack.common');
+
+module.exports = merge(common, {
+    mode: 'production'
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -9966,6 +9966,13 @@ webpack-manifest-plugin@2.0.4:
     lodash ">=3.5 <5"
     tapable "^1.0.0"
 
+webpack-merge@^4.2.1:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/webpack-merge/-/webpack-merge-4.2.1.tgz#5e923cf802ea2ace4fd5af1d3247368a633489b4"
+  integrity sha512-4p8WQyS98bUJcCvFMbdGZyZmsKuWjWVnVHnAS3FFg0HDaRVrPbkivx2RYCre8UiemD67RsiFFLfn4JhLAin8Vw==
+  dependencies:
+    lodash "^4.17.5"
+
 webpack-sources@^1.1.0, webpack-sources@^1.2.0, webpack-sources@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/webpack-sources/-/webpack-sources-1.3.0.tgz#2a28dcb9f1f45fe960d8f1493252b5ee6530fa85"


### PR DESCRIPTION
Closes #14 

**Descrição do bug/feature:**
Adicionar configuração de produção do webpack

**Solução adotada:**
Separei o arquivo de config do webpack em três arquivos:
* O common, com configurações em comum entre desenvolvimento e produção;
* O dev, com configurações específicas para desenvolvimento;
* O prod, com configurações específicas para produção

Além disso, reorganizei os arquivos numa pasta chamada `webpack`, para deixar mais coerente, e corrigi os scripts no `package.json`

**TODO:**
N/A