### PR TITLE
Adição de exemplos para jogos e TCC, e algumas alterações

### DIFF
--- a/src/lib/disciplinas.json
+++ b/src/lib/disciplinas.json
@@ -238,6 +238,8 @@
             "type": "Disciplina",
             "entry": "Jogos Digitais",
             "examples": [
+                "A prova de jogos tava muito boa",
+                "Hoje tem aula de jogos?",
                 "Se eu cursar jogos, posso ficar jogando candy crush na aula?"
             ]
         }

--- a/src/lib/disciplinas.json
+++ b/src/lib/disciplinas.json
@@ -233,11 +233,14 @@
     ],
     "JoDi": [
         {
-            "acronym": "JoDi",
-            "meaning": "Jogos Digitais",
+            "acronym": "Jogos",
+            "meaning": "Jogos Digitais é uma cadeira optativa específica do curso de Ciência da Computação.",
             "type": "Disciplina",
             "entry": "Jogos Digitais",
-            "examples": []
+            "examples": [
+                "Pra cursar jogos tem que ter coragem...",
+                "Jogos é click bait,"
+            ]
         }
     ],
     "LEDA": [
@@ -245,7 +248,7 @@
             "acronym": "LEDA",
             "entry": "Laboratório de Estrutura de Dados",
             "type": "Disciplina",
-            "meaning": "Laboratório de Estrutura de Dados é uma disciplina obrigatória do 3º período do curso de Ciência de Computação que é paga em conjunto com EDA para o aprofundamento prático dos assuntos vistos em EDA.",
+            "meaning": "Laboratório de Estrutura de Dados é uma disciplina obrigatória do 3º período do curso da Ciência de Computação que é paga em conjunto com EDA para o aprofundamento prático dos assuntos vistos em EDA.",
             "examples": [
                 "Essa prova de LEDA eu só segurei na mão de Thanos e fui.",
                 "O roteiro de LEDA dessa semana é uma viagem!"
@@ -467,10 +470,13 @@
     "TCC": [
         {
             "acronym": "TCC",
-            "meaning": "Trabalho de Conclusão de Curso",
+            "meaning": "Trabalho de Conclusão de Curso, é um trabalho obrigatório para concluir o curso de Ciência da Computação.",
             "type": "Disciplina",
             "entry": "Trabalho de Conclusão de Curso",
-            "examples": []
+            "examples": [
+                "Só falta o TCC pra acabar o curso.",
+                "E esse TCC sai ou não sai?"
+            ]
         }
     ],
     "TG": [

--- a/src/lib/disciplinas.json
+++ b/src/lib/disciplinas.json
@@ -238,8 +238,7 @@
             "type": "Disciplina",
             "entry": "Jogos Digitais",
             "examples": [
-                "Pra cursar jogos tem que ter coragem...",
-                "Jogos é click bait,"
+                "Se eu cursar jogos, posso ficar jogando candy crush na aula?"
             ]
         }
     ],

--- a/src/lib/disciplinas.json
+++ b/src/lib/disciplinas.json
@@ -471,7 +471,7 @@
     "TCC": [
         {
             "acronym": "TCC",
-            "meaning": "Trabalho de Conclusão de Curso, é um trabalho obrigatório para concluir o curso de Ciência da Computação.",
+            "meaning": "Trabalho de Conclusão de Curso, é um trabalho acadêmico obrigatório de muitos cursos de graduação que tem como função ser o instrumento de avaliação final de um curso superior.",
             "type": "Disciplina",
             "entry": "Trabalho de Conclusão de Curso",
             "examples": [

--- a/src/lib/disciplinas.json
+++ b/src/lib/disciplinas.json
@@ -249,7 +249,7 @@
             "acronym": "LEDA",
             "entry": "Laboratório de Estrutura de Dados",
             "type": "Disciplina",
-            "meaning": "Laboratório de Estrutura de Dados é uma disciplina obrigatória do 3º período do curso da Ciência de Computação que é paga em conjunto com EDA para o aprofundamento prático dos assuntos vistos em EDA.",
+            "meaning": "Laboratório de Estrutura de Dados é uma disciplina obrigatória do 3º período do curso de Ciência da Computação que é paga em conjunto com EDA para o aprofundamento prático dos assuntos vistos em EDA.",
             "examples": [
                 "Essa prova de LEDA eu só segurei na mão de Thanos e fui.",
                 "O roteiro de LEDA dessa semana é uma viagem!"


### PR DESCRIPTION
#44 

**Descrição do bug/feature:**
Foram adicionados exemplos para as disciplinas de jogos e TCC, além de melhorada sua descrição. Também foi modificada a sigla de Jogos Digitais, de JoDI para Jogos, pois é o que as pessoas mais usam.