### PR TITLE
Adição de comando 'git add' após ordenação dos dados pelo script de p…

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "husky": {
     "hooks": {
-      "pre-commit": "node src/scripts/orderData.js"
+      "pre-commit": "node src/scripts/orderData.js && git add ."
     }
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "husky": {
     "hooks": {
-      "pre-commit": "node src/scripts/orderData.js && git add ."
+      "pre-commit": "node src/scripts/orderData.js && git add src/lib"
     }
   },
   "scripts": {


### PR DESCRIPTION
…recommit do husky

Fixes #61 

**Descrição do bug/feature:**

Agora, após a ordenação, o arquivo é adicionado no commit.

**Solução adotada:**

Apenas a adição do comando `git add .` que estava faltando
