### PR TITLE
Atualiza changelog e corrige espaçamento

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ e esse projeto adere a [Semantic Versioning](https://semver.org/lang/pt-BR/spec/
 ## [Não publicado]
 ### Adicionado
 - Service Worker e Manifest.
+- Proptypes.
+
+### Corrigido
+- Script de pré commit não adiciona os arquivos ordenados no commit.
+- Falta de espaçamento na frase do termo aleatório da pesquisa.
+
+### Modificado
+- Melhoria da semântica do HTML dos componentes.
+- Componentes de classe reescritos para componentes funcionais usando Hooks.
+
+### Removido
+
+- Arquivo `/styles/material/colors.css` não utilizado.
 
 ## [1.0.0] - 17/07/2019
 

--- a/src/components/glossary/GlossaryPage.js
+++ b/src/components/glossary/GlossaryPage.js
@@ -11,7 +11,7 @@ import SearchResults from './results/SearchResults';
 const DayPhrase = ({ entry }) => {
   return (
     <span className={'glossary__day-phrase'}>
-      Você sabe o que é
+      Você sabe o que é&nbsp;
       <Link
         className='emphasis pointer-hover light-accent lighter-hover'
         to={`/${entry}`}


### PR DESCRIPTION
Estou atualizando o changelog com as contribuições recentes. Farei a release depois de merjamos a PR do prettier.

**Descrição do bug/feature:**
Falta o espaço antes do termo random.
<img width="858" alt="Screen Shot 2019-10-05 at 20 16 25" src="https://user-images.githubusercontent.com/6867958/66262063-9fee5300-e7af-11e9-8178-7f215faeafcb.png">

**Solução adotada:**
Adicionei o elemento html `&nbsp;`. É melhor porque evita as pessoas apagerem o espaço sem querer.

**TODO:**
Fazer a release