### PR TITLE
add Header component w/ react-router-prop-types

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "react-dom": "^16.7.0",
     "react-hot-loader": "^4.12.10",
     "react-markdown": "^4.0.6",
+    "react-router-prop-types": "^1.0.4",
     "react-scripts": "2.1.3",
     "webpack-merge": "^4.2.1"
   },

--- a/src/components/common/Header/Header.css
+++ b/src/components/common/Header/Header.css
@@ -1,0 +1,30 @@
+.header__search-tools {
+  padding: 1em;
+  height: 100%;
+  width: 100%;
+  display: grid;
+  grid-template-areas:
+      'logo search'
+      '. day-phrase';
+  grid-gap: 0 1em;
+  grid-template-columns: max-content minmax(max-content, 400px);
+  grid-template-rows: max-content;
+  align-items: center;
+  align-content: center;
+  justify-content: center;
+}
+
+.header__logo {
+  grid-area: logo;
+  width: 400px;
+}
+
+.header__search {
+  grid-area: search;
+  margin: 0;
+  outline: none;
+}
+
+.header__day-phrase {
+  grid-area: day-phrase;
+}

--- a/src/components/common/Header/Header.js
+++ b/src/components/common/Header/Header.js
@@ -1,11 +1,11 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import ReactRouterPropTypes from 'react-router-prop-types';
+import ReactRouterPropTypes from 'react-router-prop-types'
 
 import glossarioLogo from '../../../../assets/images/glossario-logo.svg'
 import { Search } from '../index'
 import { Link } from 'react-router-dom'
-import terms from '../../../lib/data';
+import terms from '../../../lib/data'
 
 import './Header.css'
 
@@ -28,9 +28,7 @@ DayPhrase.propTypes = {
   entry: PropTypes.string
 }
 
-const Header = (props) => {}
-export default Header
-
+const Header = (props) => {
   const handleAcronymChange = selected => {
     props.history.push(`/${selected}`);
   };
@@ -63,3 +61,5 @@ Header.propTypes = {
   location: ReactRouterPropTypes.location,
   match: ReactRouterPropTypes.match.isRequired
 }
+
+export default Header

--- a/src/components/common/Header/Header.js
+++ b/src/components/common/Header/Header.js
@@ -1,0 +1,64 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import ReactRouterPropTypes from 'react-router-prop-types';
+
+import glossarioLogo from '../../../../assets/images/glossario-logo.svg'
+import { Search } from '../index'
+import { Link } from 'react-router-dom'
+import terms from '../../../lib/data';
+
+import './Header.css'
+
+const DayPhrase = ({ entry }) => {
+  return (
+    <span className={'header__day-phrase'}>
+      Você sabe o que é&nbsp;
+      <Link
+        className='emphasis pointer-hover light-accent lighter-hover'
+        to={`/${entry}`}
+      >
+        {entry}
+      </Link>
+      ?
+    </span>
+  );
+};
+
+DayPhrase.propTypes = {
+  entry: PropTypes.string
+}
+
+export default function Header(props) {
+
+  const handleAcronymChange = selected => {
+    props.history.push(`/${selected}`);
+  };
+
+  const getRandomEntry = () => {
+    const entries = Object.keys(terms);
+    const index = Math.floor(Math.random() * entries.length);
+    return entries[index];
+  };
+
+  const getTerm = () => props.match.params.term;
+
+  const isSearchEmpty = () => {
+    return getTerm() === undefined;
+  };
+
+	return (
+		<div className={'header__search-tools'}>
+			<Link to={''} className={'header__logo'}>
+				<img src={glossarioLogo} />
+			</Link>
+			<Search className={'header__search'} items={Object.keys(terms).sort()} handleSelect={handleAcronymChange} />
+      {isSearchEmpty() && <DayPhrase entry={getRandomEntry()} />}
+		</div>
+	)
+}
+
+Header.propTypes = {
+  history: ReactRouterPropTypes.history.isRequired,
+  location: ReactRouterPropTypes.location,
+  match: ReactRouterPropTypes.match.isRequired
+}

--- a/src/components/common/Header/Header.js
+++ b/src/components/common/Header/Header.js
@@ -28,7 +28,8 @@ DayPhrase.propTypes = {
   entry: PropTypes.string
 }
 
-export default function Header(props) {
+const Header = (props) => {}
+export default Header
 
   const handleAcronymChange = selected => {
     props.history.push(`/${selected}`);

--- a/src/components/glossary/GlossaryPage.css
+++ b/src/components/glossary/GlossaryPage.css
@@ -12,37 +12,6 @@
     grid-template-rows: max-content auto;
 }
 
-.glossary__search-tools {
-    padding: 1em;
-    height: 100%;
-    width: 100%;
-    display: grid;
-    grid-template-areas:
-        'logo search'
-        '. day-phrase';
-    grid-gap: 0 1em;
-    grid-template-columns: max-content minmax(max-content, 400px);
-    grid-template-rows: max-content;
-    align-items: center;
-    align-content: center;
-    justify-content: center;
-}
-
-.glossary__day-phrase {
-    grid-area: day-phrase;
-}
-
-.glossary__logo {
-    grid-area: logo;
-    width: 400px;
-}
-
-.glossary__search {
-    grid-area: search;
-    margin: 0;
-    outline: none;
-}
-
 @media screen and (max-width: 700px) {
     .glossary__search-tools {
         grid-template-areas:

--- a/src/components/glossary/GlossaryPage.js
+++ b/src/components/glossary/GlossaryPage.js
@@ -1,27 +1,10 @@
 import React from 'react';
 import './GlossaryPage.css';
-import { Search } from '../common/index';
 import { Link } from 'react-router-dom';
-
-import glossarioLogo from '../../../assets/images/glossario-logo.svg';
 
 import terms from '../../lib/data';
 import SearchResults from './results/SearchResults';
-
-const DayPhrase = ({ entry }) => {
-  return (
-    <span className={'glossary__day-phrase'}>
-      Você sabe o que é&nbsp;
-      <Link
-        className='emphasis pointer-hover light-accent lighter-hover'
-        to={`/${entry}`}
-      >
-        {entry}
-      </Link>
-      ?
-    </span>
-  );
-};
+import Header from '../common/Header/Header';
 
 const GlossaryPage = props => {
   const handleAcronymChange = selected => {
@@ -45,17 +28,7 @@ const GlossaryPage = props => {
     : 'glossary__container--has-search';
   return (
     <div className={`glossary__container ${glossaryContainerClass}`}>
-      <div className={'glossary__search-tools'}>
-        <Link to={''} className={'glossary__logo'}>
-          <img src={glossarioLogo} />
-        </Link>
-        <Search
-          className={'glossary__search'}
-          items={Object.keys(terms).sort()}
-          handleSelect={handleAcronymChange}
-        />
-        {isSearchEmpty() && <DayPhrase entry={getRandomEntry()} />}
-      </div>
+      <Header {...props} isSearchEmpty={isSearchEmpty} />
       {!isSearchEmpty() && <SearchResults term={getTerm()} />}
     </div>
   );

--- a/src/components/glossary/GlossaryPage.js
+++ b/src/components/glossary/GlossaryPage.js
@@ -7,16 +7,6 @@ import SearchResults from './results/SearchResults';
 import Header from '../common/Header/Header';
 
 const GlossaryPage = props => {
-  const handleAcronymChange = selected => {
-    props.history.push(`/${selected}`);
-  };
-
-  const getRandomEntry = () => {
-    const entries = Object.keys(terms);
-    const index = Math.floor(Math.random() * entries.length);
-    return entries[index];
-  };
-
   const getTerm = () => props.match.params.term;
 
   const isSearchEmpty = () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1038,7 +1038,7 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-12.7.11.tgz#be879b52031cfb5d295b047f5462d8ef1a716446"
   integrity sha512-Otxmr2rrZLKRYIybtdG/sgeO+tHY20GxeDjcGmUnmmlCWyEnv2a2x1ZXBo3BTec4OiTXMQCiazB8NMBf0iRlFw==
 
-"@types/prop-types@*":
+"@types/prop-types@*", "@types/prop-types@^15.5.3":
   version "15.7.3"
   resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.3.tgz#2ab0d5da2e5815f94b0b9d4b95d1e5f243ab2ca7"
   integrity sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw==
@@ -9883,6 +9883,14 @@ react-router-dom@^4.3.1:
     prop-types "^15.6.1"
     react-router "^4.3.1"
     warning "^4.0.1"
+
+react-router-prop-types@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/react-router-prop-types/-/react-router-prop-types-1.0.4.tgz#74716e92d014bb51ee4376ee198f34903cf8dc1d"
+  integrity sha512-tXDQe0pnBTXjFivBa69hYibtgI3hz+Q/VmhMT7vIzYVPv574dd+lIuBIWOBH9dZkHeSuD6iur6zkmss3QVTeew==
+  dependencies:
+    "@types/prop-types" "^15.5.3"
+    prop-types "^15.6.1"
 
 react-router@^4.3.1:
   version "4.3.1"


### PR DESCRIPTION
Fixes #119 

**Descrição do bug/feature:**
Criação do componente `<Header />`

**Solução adotada:**
* Separação lógica e dos estilos do componente
* O componente header recebe as `props` do parent para ter acesso as funções do `react-router`
* Verificação das props através do pacote `react-router-prop-types`

**TODO:**
A separação desse componente não remove a atribuição de estilo condicional no `GlossaryPage`, conforme descrição da issue:

https://github.com/OpenDevUFCG/glossario-ufcg/blob/3f468202b017983dc5bf593719ef4ca9911cc335/src/components/glossary/GlossaryPage.js#L41

Porém, no meu entendimento, essa condicional diz como o `Header` deve se comportar na tela de acordo com o `term` passado.

Para essa condicional sumir, deve-se criar páginas separadas, uma para a "Homepage" e outra que mostra o `TermCard`, assim cada página posiciona o `Header` do jeito que for preciso. 

Fico aberto para discussões caso pensem o contrário, ou o que disse acima deve estar nesse PR também 🤗 