### PR TITLE
Agora o glossário funciona offline :)

### DIFF
--- a/public/serviceWorker.js
+++ b/public/serviceWorker.js
@@ -3,7 +3,7 @@
 
   // https://developers.google.com/web/tools/workbox
   importScripts(
-      'https://storage.googleapis.com/workbox-cdn/releases/4.3.1/workbox-sw.js'
+    'https://storage.googleapis.com/workbox-cdn/releases/4.3.1/workbox-sw.js'
   );
 
   if (!workbox) return;
@@ -12,15 +12,18 @@
 
   // Image Cache
   workbox.routing.registerRoute(
-      /\.(?:png|gif|jpg|jpeg|webp|svg)$/,
-      new workbox.strategies.CacheFirst({
-          cacheName: 'images',
-          plugins: [
-              new workbox.expiration.Plugin({
-                  maxEntries: 60,
-                  maxAgeSeconds: 30 * 24 * 60 * 60, // 30 Days
-              }),
-          ],
-      })
+    /\.(?:png|gif|jpg|jpeg|webp|svg)$/,
+    new workbox.strategies.StaleWhileRevalidate({
+      cacheName: 'images',
+      plugins: [
+        new workbox.expiration.Plugin({
+          maxEntries: 60,
+          maxAgeSeconds: 30 * 24 * 60 * 60, // 30 Days
+        }),
+      ],
+    })
   );
+
+  // Default cache
+  workbox.routing.registerRoute(/.*/, new workbox.strategies.NetworkFirst());
 })();


### PR DESCRIPTION
**Descrição do bug/feature:**

Permitir que o glossário funcione offline após um tempo de navegação pelo mesmo.

**Solução adotada:**

Ao adicionar a rota `.*` utilizando `NetworkFirst`, quando não houver internet, o conteúdo do site será carregado do cache e com isso o site funcionará mesmo quando offline.
