### PR TITLE
Adiciona disciplinas optativas gerais

### DIFF
--- a/src/lib/disciplinas.json
+++ b/src/lib/disciplinas.json
@@ -134,6 +134,17 @@
             ]
         }
     ],
+    "Direito": [
+        {
+            "acronym": "Direito",
+            "meaning": "Direito e Cidadania é uma disciplina optativa geral do curso de Ciência da Computação na UFCG, que visa analisar, de forma crítica, o fenômeno jurídico dos direitos humanos e da cidadania.",
+            "type": "Disciplina",
+            "entry": "Direito e Cidadania",
+            "examples": [
+                "A atividade de Direito é para entregar até sexta."
+            ]
+        }
+    ],
     "EDA": [
         {
             "acronym": "EDA",
@@ -317,6 +328,18 @@
                 "Quando começa o próximo lab de LP2?",
                 "Preciso terminar o terceiro lab de LP2",
                 "Eu não sei se era melhor usar herança ou interface na prova de LP2"
+            ]
+        }
+    ],
+    "LPT": [
+        {
+            "acronym": "LPT",
+            "meaning": "Língua Portuguesa (antes chamada de Leitura e Produção de Textos) é uma disciplina optativa geral do curso de Ciência da Computação na UFCG, que visa crar condições para que o aluno desenvolva aspectos comunicativos e discursivos, assim como sua capacidade de adequar a língua aos diferentes contextos.",
+            "type": "Disciplina",
+            "entry": "Língua Portuguesa",
+            "examples": [
+                "A apresentação do seminário de LPT é amanhã.",
+                "Essa semana tem resumo de LPT para entregar."
             ]
         }
     ],

--- a/src/lib/locais.json
+++ b/src/lib/locais.json
@@ -112,6 +112,16 @@
             ]
         }
     ],
+    "LQD": [
+        {
+            "meaning": "O LQD (Laboratório de Qualidade de Dados) fica no bloco CN (Bloco do lCC2) e o seu grupo de pesquisa investiga e desenvolve novas técnicas, abordagens, processos e ferramentas para avaliar e melhorar a qualidade dos conjuntos de dados.",
+            "type": "Laboratório",
+            "entry": "Laboratório de Qualidade de Dados",
+            "examples": [
+                "Pedro não quer mais sair do LQD."
+            ]
+        }
+    ],
     "Quiosque": [
         {
             "meaning": "Quiosque é a lanchonete que fica ao lado do laguinho, não tem como errar, ela é a única ali. No Quiosque você encontra lanches e também é servido almoço.",


### PR DESCRIPTION
Fixes #70 

**Descrição do bug/feature:**
Faltam as disciplinas optativas gerais no Glossário

**Solução adotada:**
Foram adicionadas as optativas gerais Língua Portuguesa e Direito e Cidadania ao arquivo disciplinas.json, seguindo a documentação dos dados.

**TODO:**
Adicionar novas disciplinas optativas gerais (ex: Informática e Sociedade).
