### PR TITLE
Adiciona Seção de Redes Sociais

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,15 +11,16 @@
     "antd": "^3.14.1",
     "eslint-plugin-jsx-a11y": "^6.2.1",
     "husky": "^1.3.1",
+    "ol": "6.0.1",
     "prop-types": "^15.7.2",
     "react": "^16.7.0",
     "react-dom": "^16.7.0",
     "react-hot-loader": "^4.12.10",
+    "react-icons": "^3.8.0",
     "react-markdown": "^4.0.6",
     "react-router-prop-types": "^1.0.4",
     "react-scripts": "2.1.3",
-    "webpack-merge": "^4.2.1",
-    "ol": "6.0.1"
+    "webpack-merge": "^4.2.1"
   },
   "husky": {
     "hooks": {

--- a/src/components/common/Social/Social.js
+++ b/src/components/common/Social/Social.js
@@ -1,0 +1,48 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import {
+    FaFacebookF, FaTwitter, FaGithub, FaInstagram,
+} from 'react-icons/fa';
+
+import './Social.css';
+
+const mapNameToComponent = {
+    facebook: FaFacebookF,
+    github: FaGithub,
+    instagram: FaInstagram,
+    twitter: FaTwitter,
+};
+
+const mapNameToUrl = {
+    facebook: social => `https://facebook.com/${social}`,
+    github: social => `https://github.com/${social}`,
+    instagram: social => `https://instagram.com/${social}`,
+    twitter: social => `https://twitter.com/${social}`,
+};
+
+const Social = ({ socialNetworks }) => {
+    if (socialNetworks == null) {
+        return (<></>);
+    }
+    return (
+        <div className="term-card__content">
+            <h2 className="term-card__title-2">Redes Sociais</h2>
+            {Object.keys(socialNetworks).map(name => {
+                const Component = mapNameToComponent[name];
+                const socialUrl = socialNetworks[name];
+                const url = mapNameToUrl[name](socialUrl);
+                return (
+                    <a href={url} key={name} rel="noopener noreferrer" target="_blank">
+                        <Component size="30px" color="#30abae" />
+                    </a>
+                );
+            })}
+        </div>
+    )
+};
+
+Social.propTypes = {
+    socialNetworks: PropTypes.object,
+};
+
+export default Social;

--- a/src/components/common/SocialMedia/SocialMedia.js
+++ b/src/components/common/SocialMedia/SocialMedia.js
@@ -1,16 +1,19 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import {
-    FaFacebookF, FaTwitter, FaGithub, FaInstagram,
+    FaFacebookF as IconFacebook,
+    FaGithub as IconGithub,
+    FaInstagram as IconInstagram,
+    FaTwitter as IconTwitter,
 } from 'react-icons/fa';
 
 import './Social.css';
 
 const mapNameToComponent = {
-    facebook: FaFacebookF,
-    github: FaGithub,
-    instagram: FaInstagram,
-    twitter: FaTwitter,
+    facebook: IconFacebook,
+    github: IconGithub,
+    instagram: IconInstagram,
+    twitter: IconTwitter,
 };
 
 const mapNameToUrl = {
@@ -20,7 +23,7 @@ const mapNameToUrl = {
     twitter: social => `https://twitter.com/${social}`,
 };
 
-const Social = ({ socialNetworks }) => {
+const SocialMedia = ({ socialNetworks }) => {
     if (socialNetworks == null) {
         return (<></>);
     }
@@ -41,8 +44,13 @@ const Social = ({ socialNetworks }) => {
     )
 };
 
-Social.propTypes = {
-    socialNetworks: PropTypes.object,
+SocialMedia.propTypes = {
+    socialNetworks: PropTypes.shape({
+        facebook: PropTypes.string,
+        github: PropTypes.string,
+        instagram: PropTypes.string,
+        twitter: PropTypes.string,
+    }),
 };
 
-export default Social;
+export default SocialMedia;

--- a/src/components/common/TermCard/TermCard.js
+++ b/src/components/common/TermCard/TermCard.js
@@ -3,7 +3,7 @@ import Markdown from '../Markdown/Markdown';
 
 import './TermCard.css';
 import LocationIfExists from '../LocationIfExists/LocalizationIfExists';
-import Social from '../Social/Social';
+import SocialMedia from '../SocialMedia/SocialMedia';
 
 import PropTypes from 'prop-types';
 
@@ -53,7 +53,7 @@ const TermCard = ({ term }) => (
     </div>
 
     <LocationIfExists entry={term.entry} location={term.location} />
-    <Social socialNetworks={term.social} />
+    <SocialMedia socialNetworks={term.social} />
   </div>
 );
 

--- a/src/components/common/TermCard/TermCard.js
+++ b/src/components/common/TermCard/TermCard.js
@@ -3,6 +3,7 @@ import Markdown from '../Markdown/Markdown';
 
 import './TermCard.css';
 import LocationIfExists from '../LocationIfExists/LocalizationIfExists';
+import Social from '../Social/Social';
 
 import PropTypes from 'prop-types';
 
@@ -52,6 +53,7 @@ const TermCard = ({ term }) => (
     </div>
 
     <LocationIfExists entry={term.entry} location={term.location} />
+    <Social socialNetworks={term.social} />
   </div>
 );
 
@@ -66,6 +68,7 @@ TermCard.propTypes = {
       latitude: PropTypes.number,
       longitude: PropTypes.number
     }),
+    social: PropTypes.object,
   }),
 };
 

--- a/src/lib/outros.json
+++ b/src/lib/outros.json
@@ -36,10 +36,13 @@
   "ELAS": [
     {
       "acronym": "ELAS",
-      "meaning": "Elas@Computação é uma comunidade de mulheres(ou que se identificam como tal) do curso de Ciência da Computação da UFCG, que inclui alunas e professoras. O grupo foi criado com o intuito de reunir as mulheres do curso, que enfrentam constantes dificuldades em um ambiente majoritariamente masculino.",
+      "meaning": "Elas@Computação é uma comunidade de mulheres (ou que se identificam como tal) do curso de Ciência da Computação da UFCG, que inclui alunas e professoras. O grupo foi criado com o intuito de reunir as mulheres do curso, que enfrentam constantes dificuldades em um ambiente majoritariamente masculino.",
       "type": "Comunidade da UFCG",
       "entry": "Elas@Computação",
-      "examples": ["O Elas está cuidando disso.", "Hoje haverá reunião do Elas"]
+      "examples": ["O Elas está cuidando disso.", "Hoje haverá reunião do Elas."],
+      "social": {
+        "instagram": "elascomputacao"
+      }
     }
   ],
   "FORK": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -9886,6 +9886,13 @@ react-hot-loader@^4.12.10:
     shallowequal "^1.1.0"
     source-map "^0.7.3"
 
+react-icons@^3.8.0:
+  version "3.8.0"
+  resolved "https://registry.yarnpkg.com/react-icons/-/react-icons-3.8.0.tgz#229de5904809696c9f46932bd9b6126b2522866e"
+  integrity sha512-rA/8GRKjPulft8BSBSMsHkE1AGPqJ7LjNsyk0BE7XjG70Iz62zOled2SJk7LDo8x9z86a3xOstDlKlMZ4pAy7A==
+  dependencies:
+    camelcase "^5.0.0"
+
 react-is@^16.7.0, react-is@^16.8.1, react-is@^16.8.6:
   version "16.10.2"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.10.2.tgz#984120fd4d16800e9a738208ab1fba422d23b5ab"


### PR DESCRIPTION
Related to #150

**Descrição do bug/feature:**
Adiciona Seção de Redes Sociais, facilitando a implementação da Issue #150.

**Solução adotada:**
Foi criado um novo componente que representa a seção de redes sociais. Com isso, as entradas do glossário que possuírem a propriedade `social` exibirão as redes sociais daquela entrada. Ver exemplo do Elas.

**PS:**
Apenas merjar após a #155 

![image](https://user-images.githubusercontent.com/23748073/67905168-4596a700-fb4f-11e9-85f9-5d20a96f1b1a.png)
