### PR TITLE
Adicionada Disciplina Economia ao JSON de disciplinas

### DIFF
--- a/src/lib/disciplinas.json
+++ b/src/lib/disciplinas.json
@@ -145,6 +145,19 @@
             ]
         }
     ],
+    "ECONOMIA": [
+        {
+            "acronym": "ECON",
+            "meaning": "Economia é uma disciplina optativa geral do curso de Ciência da Computação na UFCG que tem como objetivo o estudo de forma introdutória da Ciência Econômica",
+            "type": "Disciplina",
+            "entry": "Economia",
+            "examples" : [
+                "Estou pagando Economia como optativa nesse período",
+                "Passei o dia todo estudando para a prova de Economia"
+            ]
+        }
+
+    ],
     "EDA": [
         {
             "acronym": "EDA",


### PR DESCRIPTION
Related to #70 

**Descrição do bug/feature:**
Falta a disciplina Optativa Geral Economia no Glossário.

**Solução adotada:**
Foi adicionada a disciplina Economia ao arquivo "disciplinas.json", seguindo as instruções de documentação dos dados.

**TODO:**
Adicionar outras Optativas Gerais, como "Administração e Empreendedorismo".