### PR TITLE
Social.css mudado para SocialMedia.css em SocialMedia.js

### DIFF
--- a/src/components/common/SocialMedia/SocialMedia.js
+++ b/src/components/common/SocialMedia/SocialMedia.js
@@ -7,7 +7,7 @@ import {
     FaTwitter as IconTwitter,
 } from 'react-icons/fa';
 
-import './Social.css';
+import './SocialMedia.css';
 
 const mapNameToComponent = {
     facebook: IconFacebook,


### PR DESCRIPTION
**Descrição do bug/feature:**
Ao usar o Webpack para desenvolver, com o script `start`, ele acusava de não existir o arquivo Social.css indicado em SocialMedia.js e de fato, o arquivo CSS tem nome SocialMedia.css, portanto, mudei a importação para que esse erro não aconteça mais.

**Solução adotada:**
Linha de importação em SocialMedia.js alterada.
