### PR TITLE
fix: funcionalidade do botão de busca

### DIFF
--- a/src/components/common/Search/Search.js
+++ b/src/components/common/Search/Search.js
@@ -3,13 +3,14 @@ import './Search.css';
 import { AutoComplete, Select } from 'antd';
 import { Icon } from '../Icon';
 import PropTypes from 'prop-types';
+import { useState } from 'react';
 
 const renderOption = item => <Select.Option key={item}>{item}</Select.Option>;
 
-const CustomSearchButton = ({ handleClick }) => (
+const CustomSearchButton = ({ handleClick, selected }) => (
   <button
     className="search__button-container pointer-hover lighter-hover"
-    onClick={handleClick}
+    onClick={() => handleClick(selected)}
   >
     <Icon className="search__button" icon="search" iconColor='#FFFFFF"' />
   </button>
@@ -17,24 +18,30 @@ const CustomSearchButton = ({ handleClick }) => (
 
 CustomSearchButton.propTypes = {
   handleClick: PropTypes.func,
+  selected: PropTypes.string
 }
 
-const Search = ({ items, handleSelect }) => (
-  <aside className="search">
-    <AutoComplete
-      dataSource={items.map(renderOption)}
-      optionLabelProp="meaning"
-      placeholder="Pesquise..."
-      onSelect={e => handleSelect(e)}
-      filterOption={(inputValue, option) =>
-        option.props.children
-          .toUpperCase()
-          .indexOf(inputValue.toUpperCase()) !== -1
-      }
-    />
-    <CustomSearchButton />
-  </aside>
-);
+const Search = ({ items, handleSelect }) => {
+  const [selected, setSelected] = useState('')
+
+  return (
+    <aside className="search">
+      <AutoComplete
+        dataSource={items.map(renderOption)}
+        optionLabelProp="meaning"
+        placeholder="Pesquise..."
+        onSearch={e => setSelected(e)}
+        onSelect={e => handleSelect(e)}
+        filterOption={(inputValue, option) =>
+          option.props.children
+            .toUpperCase()
+            .indexOf(inputValue.toUpperCase()) !== -1
+        }
+      />
+      <CustomSearchButton handleClick={handleSelect} selected={selected} />
+    </aside>
+  );
+}
 
 Search.propTypes = {
   items: PropTypes.arrayOf(PropTypes.string),


### PR DESCRIPTION
Fixes #ISSUE_NUMBER
#73

**Descrição do bug/feature:**

Botão de search estava sem funcionalidade

**Solução adotada:**

Adicionar estado para salvar a busca do input de search e passar função de pesquisa e valor da barra de busca para componente de botão de busca

